### PR TITLE
AP-42 communicate connection closure

### DIFF
--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -77,14 +77,14 @@ export class Terminal extends React.PureComponent {
 
   onSocketClose() {
     this.write(this.chalk.hex(this.props.theme.error).bold(
-      "\n\r\nConnection with agent is closed"
+      "\n\r\nConnection with server is closed"
     ));
   }
 
   write(text) {
     this.term.write(text);
   }
-  
+
   render() {
     return (
       <Container>

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -75,16 +75,16 @@ export class Terminal extends React.PureComponent {
     ));
   }
 
-  write(text) {
-    this.term.write(text);
-  }
-
   onSocketClose() {
-    this.term.write(this.chalk.hex(this.props.theme.error).bold(
+    this.write(this.chalk.hex(this.props.theme.error).bold(
       "\n\r\nConnection with agent is closed"
     ));
   }
 
+  write(text) {
+    this.term.write(text);
+  }
+  
   render() {
     return (
       <Container>

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -45,6 +45,7 @@ export class Terminal extends React.PureComponent {
     this.term = new XTerm(TERMINAL_SETTINGS);
     this.chalk = new chalk.Instance(CHALK_SETTINGS);
     this.onSocketError = this.onSocketError.bind(this);
+    this.onSocketClose = this.onSocketClose.bind(this);
     this.write = this.write.bind(this);
     this.connect = this.connect.bind(this);
     this.connect();
@@ -56,6 +57,7 @@ export class Terminal extends React.PureComponent {
       `${process.env.APOLLO_WS_URL}agent/${agent.id}/shell`
     );
     socket.onerror = this.onSocketError;
+    socket.onclose = this.onSocketClose;
 
     const attachAddon = new AttachAddon(socket);
     this.term.loadAddon(attachAddon);
@@ -75,6 +77,12 @@ export class Terminal extends React.PureComponent {
 
   write(text) {
     this.term.write(text);
+  }
+
+  onSocketClose() {
+    this.term.write(this.chalk.hex(this.props.theme.error).bold(
+      "\n\r\nConnection with agent is closed"
+    ));
   }
 
   render() {

--- a/tests/components/Terminal.test.jsx
+++ b/tests/components/Terminal.test.jsx
@@ -58,7 +58,7 @@ describe('Terminal', () => {
       "Something went wrong in the connection with the agent."
     ));
     expect(termWriteSpy).toHaveBeenCalledWith(terminal.chalk.hex(darkTheme.error).bold(
-      "\n\r\nConnection with agent is closed"
+      "\n\r\nConnection with server is closed"
     ));
   });
 
@@ -77,7 +77,7 @@ describe('Terminal', () => {
     assertConnection()
     await waitForExpect(() => {
       expect(termWriteSpy).toHaveBeenCalledWith(terminal.chalk.hex(darkTheme.error).bold(
-        "\n\r\nConnection with agent is closed"
+        "\n\r\nConnection with server is closed"
       ));
     });
   });

--- a/tests/components/Terminal.test.jsx
+++ b/tests/components/Terminal.test.jsx
@@ -4,6 +4,7 @@ import { Terminal } from '../../src/components/Terminal';
 import WS from 'jest-websocket-mock';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import waitForExpect from 'wait-for-expect';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -35,7 +36,7 @@ describe('Terminal', () => {
         dispatchEvent: jest.fn(),
       })),
     });
-    termWriteSpy = jest.spyOn(Terminal.prototype, 'write'); 
+    termWriteSpy = jest.spyOn(Terminal.prototype, 'write');
     terminal = mount(<Terminal theme={darkTheme} agent={mockAgent} />).find(Terminal).instance();
   });
 
@@ -56,6 +57,9 @@ describe('Terminal', () => {
     expect(termWriteSpy).toHaveBeenCalledWith(terminal.chalk.hex(darkTheme.error).bold(
       "Something went wrong in the connection with the agent."
     ));
+    expect(termWriteSpy).toHaveBeenCalledWith(terminal.chalk.hex(darkTheme.error).bold(
+      "\n\r\nConnection with agent is closed"
+    ));
   });
 
   it('correctly writes data', async () => {
@@ -64,5 +68,17 @@ describe('Terminal', () => {
 
     assertConnection();
     expect(server).toReceiveMessage("test");
+  });
+
+  it('correctly handles connection closure', async () => {
+    await server.connected;
+    server.close();
+
+    assertConnection()
+    await waitForExpect(() => {
+      expect(termWriteSpy).toHaveBeenCalledWith(terminal.chalk.hex(darkTheme.error).bold(
+        "\n\r\nConnection with agent is closed"
+      ));
+    });
   });
 });


### PR DESCRIPTION
## Code R Ticket
_Please provide a link to the Code R Jira ticket if applicable_

<https://partypeak.atlassian.net/browse/AP-42>

## Description
Prints informative text in terminal when remote closes the connection.

## Dependencies
_Are there any dependencies in relation to pull requests in other Apollo repositories? If so please provide links to these pull requests_

Related but not dependant:
* https://github.com/thecoderstudio/apollo/pull/28 to get informative about agent disconnects.

## Additional notes
Nope
